### PR TITLE
Update changelog for mu-server 2.2.10

### DIFF
--- a/src/main/resources/views/changelog.html
+++ b/src/main/resources/views/changelog.html
@@ -18,6 +18,13 @@
 <div class="changelog">
 
     <div class="release minor">
+        <h2>2.2.10</h2>
+        <ul>
+            <li>Upgraded Netty to 4.1.135</li>
+        </ul>
+    </div>
+
+    <div class="release minor">
         <h2>2.2.8</h2>
         <ul>
             <li>Upgraded Netty to 4.1.133</li>


### PR DESCRIPTION
### Motivation
- Publish release notes for mu-server 2.2.10 to inform users about the dependency upgrade.

### Description
- Added a `2.2.10` entry to `src/main/resources/views/changelog.html` stating `Upgraded Netty to 4.1.135`.

### Testing
- Ran `mvn test` and all automated tests completed successfully (`BUILD SUCCESS`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22bbb4db6c832f938ddba37a5f7d46)